### PR TITLE
On recent IBM Java 8 versions, PlatformMXBeans are not implementing a…

### DIFF
--- a/com.googlecode.xm4was.jmx/src/com/googlecode/xm4was/jmx/mxbeans/AccessControlProxy.java
+++ b/com.googlecode.xm4was.jmx/src/com/googlecode/xm4was/jmx/mxbeans/AccessControlProxy.java
@@ -12,6 +12,7 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
 import javax.management.MBeanInfo;
 import javax.management.ReflectionException;
+import javax.management.StandardMBean;
 
 public class AccessControlProxy implements DynamicMBean {
     private final Map<String,String> attributeNameToGetterNameMap = new HashMap<String,String>();
@@ -21,11 +22,18 @@ public class AccessControlProxy implements DynamicMBean {
     private final String type;
     private final AccessChecker accessChecker;
     
-    public AccessControlProxy(DynamicMBean target, String type, AccessChecker accessChecker) {
-        this.target = target;
+    public AccessControlProxy(Object target, String type, AccessChecker accessChecker) {
+        if (target instanceof DynamicMBean)
+        {
+            this.target = (DynamicMBean)target;
+        }
+        else
+        {
+            this.target = new StandardMBean(target, null, true);
+        }
         this.type = type;
         this.accessChecker = accessChecker;
-        for (MBeanAttributeInfo info : target.getMBeanInfo().getAttributes()) {
+        for (MBeanAttributeInfo info : this.target.getMBeanInfo().getAttributes()) {
             String name = info.getName();
             attributeNameToGetterNameMap.put(name, info.isIs() ? "is" + name : "get" + name);
             attributeNameToSetterNameMap.put(name, "set" + name);

--- a/com.googlecode.xm4was.jmx/src/com/googlecode/xm4was/jmx/mxbeans/PlatformMXBeansRegistrations.java
+++ b/com.googlecode.xm4was.jmx/src/com/googlecode/xm4was/jmx/mxbeans/PlatformMXBeansRegistrations.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.management.DynamicMBean;
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -35,7 +34,7 @@ public class PlatformMXBeansRegistrations {
             LOGGER.entering("PlatformMXBeansRegistrations", "registerMBean", new Object[] { object, name });
         }
         try {
-            mbs.registerMBean(new AccessControlProxy((DynamicMBean)object, name.getKeyProperty("type"), accessChecker), name);
+            mbs.registerMBean(new AccessControlProxy(object, name.getKeyProperty("type"), accessChecker), name);
             registeredMBeans.add(name);
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.log(Level.FINEST, "Registered MBean " + name + " (type " + object.getClass().getName() + ")");


### PR DESCRIPTION
Hi,
On recent IBM Java 8 versions, PlatformMXBeans are not implementing anymore DynamicMBean interface. This is causing ClassCastException:
```
[10/26/18 10:47:21:192 EEST] 00000001 PlatformMXBea E   XMJMX0103E: Failed to register platform MXBeans:
java.lang.ClassCastException: com.ibm.java.lang.management.internal.ClassLoadingMXBeanImpl incompatible with javax.management.DynamicMBean
        at com.googlecode.xm4was.jmx.mxbeans.PlatformMXBeansRegistrations.registerMBean(PlatformMXBeansRegistrations.java:39)
        ...
```
Fixed by checking first if object implements DynamicMBean and if not then it's wrapped to StandardMBean.